### PR TITLE
Add deploy runbook, systemd unit, and release migration helper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-# Extend from the official Elixir image
+# LOCAL DEVELOPMENT ONLY.
+# Production deploys use mix release + systemd on an exe.dev VM —
+# see deploy/README.md. This image is convenient for `docker compose
+# -f docker-compose.dev.yml up` and is not on the production path.
+# The Elixir version pinned here is intentionally not kept in sync
+# with the production toolchain in .tool-versions.
 FROM elixir:1.10
 
 RUN apt-get update && \

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,18 @@
+# Copy to /etc/webludo/webludo.env on the VM, replace placeholders, chmod 640.
+# Owner root:webludo so the systemd unit can read it but the user cannot edit it.
+
+# Database connection. Match the role and database created during VM bootstrap.
+DATABASE_URL=ecto://webludo:CHANGE_ME@localhost/webludo_prod
+
+# Phoenix session signing secret. Generate with: mix phx.gen.secret
+SECRET_KEY_BASE=CHANGE_ME
+
+# Public hostname the API serves under. Used for URL generation only —
+# request routing is handled by the exe.dev edge proxy.
+PHX_HOST=webludo-api.oni.dev
+
+# Loopback port the release binds to. The exe.dev proxy forwards to this port.
+PORT=4000
+
+# Ecto connection pool size.
+POOL_SIZE=10

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,198 @@
+# Deploying webludo-server to an exe.dev VM
+
+This runbook covers a single-VM deploy: a `mix release` running under systemd,
+Postgres on the same host, TLS terminated by the exe.dev edge proxy.
+
+## Layout
+
+```
+/opt/webludo/repo               git clone, owned by the webludo user
+  _build/prod/rel/webludo/bin/  release entrypoint (built on the VM)
+/etc/webludo/webludo.env        env file, root:webludo 0640
+/etc/systemd/system/webludo.service   systemd unit
+```
+
+The exe.dev edge proxy terminates TLS and forwards requests for
+`webludo-api.oni.dev` to `127.0.0.1:4000` on the VM. The release binds to
+loopback only — never expose the port on a public interface.
+
+## Prerequisites
+
+- A fresh exe.dev VM (Debian/Ubuntu) with sudo and SSH access.
+- DNS for `webludo-api.oni.dev` pointing at the VM (or controlled via the
+  exe.dev custom-domain mapping).
+- A local clone of this repo to copy commands from.
+
+## 1. VM bootstrap
+
+Install packages and the Erlang/Elixir toolchain. The Erlang Solutions apt
+repo tracks recent versions; stock distro packages typically lag too far for
+the toolchain pinned in `.tool-versions`.
+
+```bash
+sudo apt update
+sudo apt install -y build-essential git curl gnupg lsb-release \
+  libssl-dev libncurses-dev postgresql postgresql-contrib
+
+# Erlang Solutions apt source
+curl -fsSL https://binaries2.erlang-solutions.com/GPG-KEY-pmanager.asc \
+  | sudo gpg --dearmor -o /usr/share/keyrings/erlang-solutions.gpg
+echo "deb [signed-by=/usr/share/keyrings/erlang-solutions.gpg] https://binaries2.erlang-solutions.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/ $(lsb_release -cs) contrib" \
+  | sudo tee /etc/apt/sources.list.d/erlang-solutions.list
+sudo apt update
+sudo apt install -y esl-erlang elixir
+```
+
+Verify the versions match `.tool-versions` at the repo root:
+
+```bash
+elixir --version    # expect Elixir 1.19.x / Erlang/OTP 28
+```
+
+If Erlang Solutions is behind, fall back to asdf — `.tool-versions` will
+drive the install.
+
+## 2. Application user and directories
+
+```bash
+sudo useradd --system --home /opt/webludo --shell /usr/sbin/nologin webludo
+sudo mkdir -p /opt/webludo /etc/webludo
+sudo chown webludo:webludo /opt/webludo
+sudo chown root:webludo /etc/webludo && sudo chmod 750 /etc/webludo
+```
+
+## 3. Postgres role and database
+
+```bash
+sudo -u postgres psql <<'SQL'
+CREATE ROLE webludo WITH LOGIN PASSWORD 'CHANGE_ME';
+CREATE DATABASE webludo_prod OWNER webludo;
+SQL
+```
+
+Pick a strong password; you will paste it into `webludo.env` next.
+
+## 4. Env file
+
+```bash
+sudo cp deploy/.env.example /etc/webludo/webludo.env
+sudo chown root:webludo /etc/webludo/webludo.env
+sudo chmod 640 /etc/webludo/webludo.env
+sudo -e /etc/webludo/webludo.env
+```
+
+Fill in:
+
+- `DATABASE_URL` — `ecto://webludo:<password>@localhost/webludo_prod`
+- `SECRET_KEY_BASE` — generate with `mix phx.gen.secret` (any host with
+  Elixir works, including the VM after step 1).
+- `PHX_HOST` — `webludo-api.oni.dev`.
+- `PORT` — `4000` (must match the exe.dev edge mapping in step 8).
+
+## 5. Clone the repo
+
+```bash
+sudo -u webludo git clone https://github.com/oniskanen/webludo-server.git /opt/webludo/repo
+cd /opt/webludo/repo
+```
+
+## 6. Build the release
+
+Run as the `webludo` user so build artefacts are owned correctly.
+
+```bash
+sudo -iu webludo bash -c '
+  cd /opt/webludo/repo &&
+  mix local.hex --force &&
+  mix local.rebar --force &&
+  MIX_ENV=prod mix deps.get --only prod &&
+  MIX_ENV=prod mix release --overwrite
+'
+```
+
+## 7. First-run migrations
+
+```bash
+sudo -iu webludo bash -c '
+  set -a && . /etc/webludo/webludo.env && set +a &&
+  /opt/webludo/repo/_build/prod/rel/webludo/bin/webludo eval "WebLudo.Release.migrate"
+'
+```
+
+`set -a` exports the env vars to the eval subprocess. The release task
+applies all pending migrations and exits.
+
+## 8. Systemd unit and edge mapping
+
+```bash
+sudo cp /opt/webludo/repo/deploy/webludo.service /etc/systemd/system/webludo.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now webludo
+sudo systemctl status webludo
+```
+
+In the exe.dev console, map the custom domain `webludo-api.oni.dev` to
+port `4000` of this VM (refer to exe.dev docs for the current console
+flow). TLS provisioning is automatic.
+
+## 9. Verify
+
+```bash
+curl -sS -o /dev/null -w "%{http_code}\n" https://webludo-api.oni.dev/socket/websocket
+```
+
+A `400` or `426` is expected — the websocket endpoint rejects plain HTTP
+upgrade attempts but proves the path is wired end to end. The frontend at
+`https://webludo.katris.dev` should now connect.
+
+## Subsequent deploys
+
+```bash
+sudo -iu webludo bash -c '
+  cd /opt/webludo/repo &&
+  git pull --ff-only &&
+  MIX_ENV=prod mix deps.get --only prod &&
+  MIX_ENV=prod mix release --overwrite
+'
+sudo -iu webludo bash -c '
+  set -a && . /etc/webludo/webludo.env && set +a &&
+  /opt/webludo/repo/_build/prod/rel/webludo/bin/webludo eval "WebLudo.Release.migrate"
+'
+sudo systemctl restart webludo
+```
+
+If a deploy has no migrations, the eval step is a no-op and safe to skip.
+
+## Logs
+
+```bash
+sudo journalctl -u webludo -f      # follow live
+sudo journalctl -u webludo -n 200  # last 200 lines
+```
+
+## Rollback
+
+To roll back code, check out the previous commit and rebuild:
+
+```bash
+sudo -iu webludo bash -c '
+  cd /opt/webludo/repo &&
+  git log --oneline -10 &&
+  git checkout <previous-sha> &&
+  MIX_ENV=prod mix release --overwrite
+'
+sudo systemctl restart webludo
+```
+
+To roll back a migration:
+
+```bash
+sudo -iu webludo bash -c '
+  set -a && . /etc/webludo/webludo.env && set +a &&
+  /opt/webludo/repo/_build/prod/rel/webludo/bin/webludo eval \
+    "WebLudo.Release.rollback(WebLudo.Repo, <version>)"
+'
+```
+
+`<version>` is the timestamp prefix on the migration filename in
+`priv/repo/migrations/`.

--- a/deploy/webludo.service
+++ b/deploy/webludo.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=WebLudo Phoenix release
+After=network.target postgresql.service
+Wants=postgresql.service
+
+[Service]
+Type=simple
+User=webludo
+Group=webludo
+WorkingDirectory=/opt/webludo/repo
+EnvironmentFile=/etc/webludo/webludo.env
+ExecStart=/opt/webludo/repo/_build/prod/rel/webludo/bin/webludo start
+ExecStop=/opt/webludo/repo/_build/prod/rel/webludo/bin/webludo stop
+Restart=on-failure
+RestartSec=5
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,8 @@
+# LOCAL DEVELOPMENT ONLY.
+# Production deploys use mix release + systemd on an exe.dev VM —
+# see deploy/README.md. Bring up the db service alone with
+# `docker compose -f docker-compose.dev.yml up -d db` if you only
+# need Postgres for `mix test` or local iex sessions.
 version: '3'
 
 services:

--- a/lib/webludo/release.ex
+++ b/lib/webludo/release.ex
@@ -1,0 +1,28 @@
+defmodule WebLudo.Release do
+  @moduledoc """
+  Tasks invoked from a release where Mix is unavailable. See `deploy/README.md`.
+  """
+
+  @app :webludo
+
+  def migrate do
+    load_app()
+
+    for repo <- repos() do
+      {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
+    end
+  end
+
+  def rollback(repo, version) do
+    load_app()
+    {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
+  end
+
+  defp repos do
+    Application.fetch_env!(@app, :ecto_repos)
+  end
+
+  defp load_app do
+    Application.load(@app)
+  end
+end


### PR DESCRIPTION
## Summary
- `lib/webludo/release.ex` exposes `migrate/0` and `rollback/2` so an installed release without Mix can apply schema changes via `bin/webludo eval`.
- `deploy/webludo.service` runs the release as a dedicated `webludo` user, reads `/etc/webludo/webludo.env`, and restarts on failure.
- `deploy/.env.example` documents the env contract from `config/runtime.exs`.
- `deploy/README.md` is a single-VM runbook covering: apt + Erlang Solutions toolchain, Postgres role and DB, env file layout, build, migrate, systemctl, exe.dev custom-domain mapping, subsequent deploys, logs, rollback.
- `Dockerfile` and `docker-compose.dev.yml` carry top-of-file notes clarifying they are local-dev only and intentionally diverge from the production toolchain in `.tool-versions`.

## Test plan
- [x] `MIX_ENV=prod mix release --overwrite` builds successfully on the new tree.
- [x] `bin/webludo eval "WebLudo.Release.migrate"` applies all migrations against an empty `webludo_prod` DB.
- [ ] CI green.
- [ ] Runbook validated on a fresh exe.dev VM (Task 4 — Olli executes manually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)