### PR TITLE
Assign opposite colors to teams in 2-team games

### DIFF
--- a/lib/webludo/logic.ex
+++ b/lib/webludo/logic.ex
@@ -1008,12 +1008,15 @@ defmodule WebLudo.Logic do
     team_count = length(teams_with_players)
 
     if team_count >= Constants.min_team_count() do
-      # TODO: In 2 team games, assign teams opposite one another
       random_colors =
-        Constants.team_colors()
-        |> Enum.map(fn c -> {c, :rand.uniform_real()} end)
-        |> Enum.sort_by(fn {_c, rand} -> rand end)
-        |> Enum.map(fn {c, _r} -> c end)
+        case team_count do
+          2 ->
+            {a, b} = Enum.random(Constants.opposite_color_pairs())
+            Enum.shuffle([a, b])
+
+          _ ->
+            Enum.shuffle(Constants.team_colors())
+        end
 
       teams =
         0..(team_count - 1)

--- a/lib/webludo/logic/constants.ex
+++ b/lib/webludo/logic/constants.ex
@@ -2,6 +2,10 @@ defmodule WebLudo.Logic.Constants do
   @team_colors [:red, :blue, :yellow, :green]
   @short_track_indices [0, 1, 2, 3]
 
+  # Pairs of colors whose home spaces are 14 apart on the 28-space track —
+  # i.e. directly across the board from one another.
+  @opposite_color_pairs [{:red, :yellow}, {:blue, :green}]
+
   @team_order %{
     red: :blue,
     blue: :yellow,
@@ -38,6 +42,10 @@ defmodule WebLudo.Logic.Constants do
 
   def team_colors do
     @team_colors
+  end
+
+  def opposite_color_pairs do
+    @opposite_color_pairs
   end
 
   def next_team(color) do

--- a/test/logic/game_setup_test.exs
+++ b/test/logic/game_setup_test.exs
@@ -124,6 +124,65 @@ defmodule WebLudo.Logic.GameSetupTest do
     assert Enum.any?(game.teams, fn t -> t.color == :green end)
   end
 
+  @opposite_pairs [MapSet.new([:red, :yellow]), MapSet.new([:blue, :green])]
+
+  defp two_team_fixture do
+    TestHelpers.setup_game_fixture(%{players: [%{name: "P1"}, %{name: "P2"}]})
+  end
+
+  defp two_team_colors_ordered(game) do
+    game.teams
+    |> Enum.sort_by(& &1.sort_value)
+    |> Enum.map(& &1.color)
+  end
+
+  test "two-team game always assigns an opposite-color pair" do
+    :rand.seed(:exsss, {1, 2, 3})
+
+    for _ <- 1..30 do
+      {:ok, game} = Logic.start_game(two_team_fixture())
+
+      colors = MapSet.new(Enum.map(game.teams, & &1.color))
+
+      assert colors in @opposite_pairs,
+             "Expected an opposite-color pair, got #{inspect(MapSet.to_list(colors))}"
+    end
+  end
+
+  test "two-team game reaches all four ordered configurations over many trials" do
+    :rand.seed(:exsss, {1, 2, 3})
+
+    seen =
+      Enum.reduce_while(1..200, MapSet.new(), fn _i, acc ->
+        {:ok, game} = Logic.start_game(two_team_fixture())
+        acc = MapSet.put(acc, two_team_colors_ordered(game))
+        if MapSet.size(acc) == 4, do: {:halt, acc}, else: {:cont, acc}
+      end)
+
+    expected =
+      MapSet.new([
+        [:red, :yellow],
+        [:yellow, :red],
+        [:blue, :green],
+        [:green, :blue]
+      ])
+
+    assert seen == expected
+  end
+
+  test "three-team game still uses three distinct colors from the four" do
+    game =
+      TestHelpers.setup_game_fixture(%{
+        players: [%{name: "P1"}, %{name: "P2"}, %{name: "P3"}]
+      })
+
+    assert {:ok, game} = Logic.start_game(game)
+
+    colors = MapSet.new(Enum.map(game.teams, & &1.color))
+    assert MapSet.size(colors) == 3
+    assert MapSet.subset?(colors, MapSet.new([:red, :blue, :yellow, :green]))
+  end
+
   test "starting a game creates 4 pieces in home for playing teams" do
     game = TestHelpers.setup_game_fixture()
 


### PR DESCRIPTION
Closes the long-standing TODO in `lib/webludo/logic.ex` (`# In 2 team games, assign teams opposite one another`).

## Spec

When `Logic.start_game/1` runs with exactly two teams that have at least one player, the two teams are assigned colors that are opposite on the board.

Opposite pairs follow from `Constants.get_home_space_index/1`: red:0, blue:7, yellow:14, green:21 on a 28-space track. Pairs 14 apart — directly across the board — are **{red, yellow}** and **{blue, green}**.

For 1-, 3-, and 4-team games: color assignment is unchanged (uniform shuffle of all four colors, take first N).

## Acceptance criteria

1. After `start_game/1` on a 2-team game, the two teams' color set is `{:red, :yellow}` or `{:blue, :green}`. Never anything else.
2. Both opposite pairs are reachable, and within each pair both color orderings are reachable. Selection is uniformly random.
3. 1-, 3-, and 4-team games' color assignment is unchanged.
4. Unrelated side effects of `start_game/1` (deleting empty teams, creating four home pieces per playing team, `has_started`, `current_team`, default team names) are unchanged.

## Workflow

Followed the human-in-the-loop pattern: failing tests landed first (commit `e555580`), reviewed and approved, then implementation landed in a separate commit (`efa339c`). Reviewing the two commits in order shows the spec-→-test-→-impl progression.

## Test design

Three new tests in `test/logic/game_setup_test.exs`, each preseeding `:rand` with `{1, 2, 3}` for reproducibility:

- **two-team game always assigns an opposite-color pair** — 30 trials, asserts each result is one of the two opposite pairs. Probabilistic guarantee against the prior implementation: `(2/6)^30 ≈ 5e-15`.
- **two-team game reaches all four ordered configurations** — bounded reachability loop (`Enum.reduce_while` over 1..200) with short-circuit once the four ordered configurations have been observed. Asserts the seen set equals `{[:red, :yellow], [:yellow, :red], [:blue, :green], [:green, :blue]}`.
- **three-team game still uses three distinct colors** — regression guard so the non-2 branch can't silently degrade.

## Implementation

`lib/webludo/logic/constants.ex` exposes the opposite pairs:

```elixir
@opposite_color_pairs [{:red, :yellow}, {:blue, :green}]
def opposite_color_pairs, do: @opposite_color_pairs
```

`Logic.start_game/1` branches on `team_count`:

```elixir
random_colors =
  case team_count do
    2 ->
      {a, b} = Enum.random(Constants.opposite_color_pairs())
      Enum.shuffle([a, b])

    _ ->
      Enum.shuffle(Constants.team_colors())
  end
```

The other branches use `Enum.shuffle/1` instead of the prior `:rand.uniform_real() + sort_by` form (distributionally equivalent, one line).

## Test plan

- [x] Both new 2-team tests fail on the prior implementation (verified by running the test commit before applying the implementation commit).
- [x] All 153 tests pass after the implementation lands locally on Elixir 1.19.5 / OTP 28.5.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)