### PR TITLE
Wrap execute_move in a transaction

### DIFF
--- a/lib/webludo/logic.ex
+++ b/lib/webludo/logic.ex
@@ -560,6 +560,13 @@ defmodule WebLudo.Logic do
         %Game{current_team: current_team, has_started: true} = game,
         %Move{type: type} = move
       ) do
+    {:ok, result} =
+      Repo.transaction(fn -> execute_move_inner(game, current_team, move, type) end)
+
+    result
+  end
+
+  defp execute_move_inner(game, current_team, %Move{} = move, type) do
     piece = get_piece(move.piece_id)
 
     game = game |> Repo.preload(:pieces) |> Repo.preload(:players)

--- a/lib/webludo_web/channels/game_channel.ex
+++ b/lib/webludo_web/channels/game_channel.ex
@@ -55,52 +55,6 @@ defmodule WebLudoWeb.GameChannel do
     end
   end
 
-  defp handle_move_action(game, player, move, socket) do
-    current_team = game.current_team
-
-    case current_team == player.team.color do
-      false ->
-        {:reply, {:error, %{error: "It is the #{current_team} team's turn"}}, socket}
-
-      true ->
-        moves = Logic.get_moves(game)
-
-        case moves do
-          [] ->
-            {:reply, {:error, %{message: "No moves available"}}, socket}
-
-          moves ->
-            validated_move = Enum.find(moves, fn m -> m.piece_id == move["piece_id"] end)
-
-            case validated_move do
-              nil ->
-                {:reply, {:error, %{message: "Not a valid move"}}, socket}
-
-              m ->
-                {game, changes} = Logic.execute_move(game, m)
-
-                penalties = Map.get(changes, :penalties, [])
-                game = Logic.apply_penalties(game, penalties)
-
-                handle_penalty_announcement(penalties, socket)
-
-                finishing_teams = Map.get(changes, :finishing_teams, [])
-                handle_finish_announcement(finishing_teams, socket)
-
-                multiplied_piece = Map.get(changes, :doubled, %{})
-                handle_multiplied_announcement(multiplied_piece, socket)
-
-                raise_info = Map.get(changes, :raise, %{})
-                handle_raise_announcement(raise_info, socket)
-
-                broadcast!(socket, "game_updated", %{game: game, changes: changes, actions: []})
-
-                {:reply, :ok, socket}
-            end
-        end
-    end
-  end
-
   def handle_in("join_game", %{"name" => name}, socket) do
     {:ok, game} = Logic.get_game_by_code(socket.assigns.code)
     {:ok, player} = Logic.create_player(game, %{name: name})
@@ -347,6 +301,52 @@ defmodule WebLudoWeb.GameChannel do
 
           {:error, message} ->
             {:reply, {:error, %{message: message}}, socket}
+        end
+    end
+  end
+
+  defp handle_move_action(game, player, move, socket) do
+    current_team = game.current_team
+
+    case current_team == player.team.color do
+      false ->
+        {:reply, {:error, %{error: "It is the #{current_team} team's turn"}}, socket}
+
+      true ->
+        moves = Logic.get_moves(game)
+
+        case moves do
+          [] ->
+            {:reply, {:error, %{message: "No moves available"}}, socket}
+
+          moves ->
+            validated_move = Enum.find(moves, fn m -> m.piece_id == move["piece_id"] end)
+
+            case validated_move do
+              nil ->
+                {:reply, {:error, %{message: "Not a valid move"}}, socket}
+
+              m ->
+                {game, changes} = Logic.execute_move(game, m)
+
+                penalties = Map.get(changes, :penalties, [])
+                game = Logic.apply_penalties(game, penalties)
+
+                handle_penalty_announcement(penalties, socket)
+
+                finishing_teams = Map.get(changes, :finishing_teams, [])
+                handle_finish_announcement(finishing_teams, socket)
+
+                multiplied_piece = Map.get(changes, :doubled, %{})
+                handle_multiplied_announcement(multiplied_piece, socket)
+
+                raise_info = Map.get(changes, :raise, %{})
+                handle_raise_announcement(raise_info, socket)
+
+                broadcast!(socket, "game_updated", %{game: game, changes: changes, actions: []})
+
+                {:reply, :ok, socket}
+            end
         end
     end
   end


### PR DESCRIPTION
## Summary
`Logic.execute_move/2` mutates many rows inside one user action: piece updates for the move itself, piece updates for any captured/demoted pieces, team updates for raise/game-end/hembo bookkeeping, and finally the game record's `current_team`/`roll`/`roll_count`. Previously each was an independent `Repo.update`. Two failure modes:

- A mid-move failure (constraint violation, raise during a helper, etc.) leaves the earlier writes committed and the game inconsistent.
- Two concurrent moves on the same game can interleave reads and writes — a real concern in a multiplayer game.

This PR wraps the entire body in `Repo.transaction`. The body is extracted into a private `execute_move_inner/4` to keep the diff small and avoid re-indenting the function. The pre-existing `{:ok, _} = update_piece(...)` matches in the body now roll back the whole move on any mutation failure (the raised `MatchError` is caught by `Repo.transaction`, which rolls back and re-raises). The successful return shape `{game, changes}` is preserved by unwrapping the `{:ok, _}` the transaction returns.

Also moves a private helper (`handle_move_action/4`) in `WebLudoWeb.GameChannel` down next to the other private helpers — defining it between two `handle_in/3` clauses produced a "clauses with the same name and arity should be grouped together" warning that `mix compile --warnings-as-errors` catches.

## Test plan
- [x] `mix test` — 155 tests, 0 failures locally on Elixir 1.19.5 / OTP 28.5. Existing tests cover the success path; the transaction wrap is non-disruptive on success.
- [x] `mix compile --warnings-as-errors` — clean.
- [ ] CI green.

A property test for transactional rollback would require injecting a partial failure into one of the helpers, which is more test infrastructure than the fix itself. The structural fix is self-evident in the diff.

## Out of scope
`Logic.apply_penalties` is called by `WebLudoWeb.GameChannel` after `execute_move` returns, so penalties are applied in a separate transaction from the move itself. Closing that gap would require moving the call into `Logic` and is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)