### PR TITLE
Enforce mix format and warnings-as-errors in CI

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,6 +1,5 @@
 [
   import_deps: [:ecto, :ecto_sql, :phoenix],
   inputs: ["*.{ex,exs}", "priv/*/seeds.exs", "{config,lib,test}/**/*.{ex,exs}"],
-  subdirectories: ["priv/*/migrations"],
-  plugins: [Phoenix.LiveView.HTLMFormatter]
+  subdirectories: ["priv/*/migrations"]
 ]

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -40,6 +40,10 @@ jobs:
         restore-keys: ${{ runner.os }}-mix-
     - name: Install dependencies
       run: mix deps.get
+    - name: Check formatting
+      run: mix format --check-formatted
+    - name: Compile with warnings as errors
+      run: mix compile --warnings-as-errors
     - name: Run tests
       run: mix test
 

--- a/lib/webludo/repo.ex
+++ b/lib/webludo/repo.ex
@@ -4,17 +4,19 @@ defmodule WebLudo.Repo do
     adapter: Ecto.Adapters.Postgres
 
   defp env_config() do
-    env = Keyword.new()
+    env =
+      Keyword.new()
       |> Keyword.put(:username, System.get_env("PGUSER"))
       |> Keyword.put(:password, System.get_env("PGPASSWORD"))
       |> Keyword.put(:database, System.get_env("PGDATABASE"))
       |> Keyword.put(:hostname, System.get_env("PGHOST"))
+
     port_str = System.get_env("PGPORT")
 
     if port_str == nil do
       env
     else
-      env |> Keyword.put(:port, port_str |> String.to_integer)
+      env |> Keyword.put(:port, port_str |> String.to_integer())
     end
   end
 
@@ -27,10 +29,11 @@ defmodule WebLudo.Repo do
   end
 
   def init(_, config) do
-    config = Keyword.merge(config, env_config(),
-      fn k, base, env ->
+    config =
+      Keyword.merge(config, env_config(), fn k, base, env ->
         merge_config(k, base, env)
       end)
+
     {:ok, config}
   end
 end

--- a/lib/webludo_web/channels/game_channel.ex
+++ b/lib/webludo_web/channels/game_channel.ex
@@ -166,9 +166,7 @@ defmodule WebLudoWeb.GameChannel do
 
         if match?({:reply, :ok, _}, response) do
           announce(
-            "The #{String.capitalize(to_string(color))} team fixed their penalty value to #{amount} (used to be #{
-              previous_penalties
-            }).",
+            "The #{String.capitalize(to_string(color))} team fixed their penalty value to #{amount} (used to be #{previous_penalties}).",
             socket
           )
         end
@@ -291,9 +289,7 @@ defmodule WebLudoWeb.GameChannel do
             broadcast!(socket, "game_updated", %{game: game, actions: moves})
 
             announce(
-              "The #{String.capitalize(to_string(team.color))} team missed calling hembo. Penalty to the #{
-                String.capitalize(to_string(team.color))
-              } team.",
+              "The #{String.capitalize(to_string(team.color))} team missed calling hembo. Penalty to the #{String.capitalize(to_string(team.color))} team.",
               socket
             )
 
@@ -406,33 +402,25 @@ defmodule WebLudoWeb.GameChannel do
     case penalties do
       [%{team: color, amount: 1, type: "eat"}] ->
         announce(
-          "#{String.capitalize(to_string(color))} team piece eaten! Penalty to the #{
-            String.capitalize(to_string(color))
-          } team.",
+          "#{String.capitalize(to_string(color))} team piece eaten! Penalty to the #{String.capitalize(to_string(color))} team.",
           socket
         )
 
       [%{team: color, amount: amount, eaten: eaten, eater: eater, type: "eat"}] ->
         announce(
-          "#{String.capitalize(to_string(color))} team #{eaten} eaten by a #{eater}! #{amount} penalties to the #{
-            String.capitalize(to_string(color))
-          } team.",
+          "#{String.capitalize(to_string(color))} team #{eaten} eaten by a #{eater}! #{amount} penalties to the #{String.capitalize(to_string(color))} team.",
           socket
         )
 
       [%{team: color, amount: 1, type: "mine"}] ->
         announce(
-          "#{String.capitalize(to_string(color))} team walks into a mine! Penalty to the #{
-            String.capitalize(to_string(color))
-          } team.",
+          "#{String.capitalize(to_string(color))} team walks into a mine! Penalty to the #{String.capitalize(to_string(color))} team.",
           socket
         )
 
       [%{team: color, amount: amount, eaten: eaten, eater: eater, type: "mine"}] ->
         announce(
-          "#{String.capitalize(to_string(color))} team walks a #{eaten} into a #{eater} mine! #{
-            amount
-          } penalties to the #{String.capitalize(to_string(color))} team.",
+          "#{String.capitalize(to_string(color))} team walks a #{eaten} into a #{eater} mine! #{amount} penalties to the #{String.capitalize(to_string(color))} team.",
           socket
         )
 

--- a/priv/repo/migrations/20200321133702_create_players.exs
+++ b/priv/repo/migrations/20200321133702_create_players.exs
@@ -9,6 +9,5 @@ defmodule WebLudo.Repo.Migrations.CreatePlayers do
 
       timestamps()
     end
-
   end
 end


### PR DESCRIPTION
## Summary
Two new steps in `.github/workflows/elixir.yml` between deps and tests:

- `mix format --check-formatted` — would have caught the formatting drift this PR cleans up.
- `mix compile --warnings-as-errors` — would have caught the `handle_in/3` grouping warning that PR #46 had to fix retroactively.

Pre-existing fixes pulled into this commit so CI starts green:

- `.formatter.exs` referenced `Phoenix.LiveView.HTLMFormatter` (typo for `HTMLFormatter`, plus `phoenix_live_view` isn't a dep — this is an API-only server). Plugin entry removed.
- `mix format` applied to `lib/webludo_web/channels/game_channel.ex` (long string interpolations the newer formatter unwraps onto one line) and `lib/webludo/repo.ex` (pipe alignment, optional parens).
- Whitespace-only fix to a historical migration's trailing blank line. The "do not edit historical migrations" convention is about schema replay safety; whitespace doesn't affect tokenization or execution semantics, so a one-time formatter sweep is in scope.

## Test plan
- [x] `mix format --check-formatted` clean locally.
- [x] `mix compile --warnings-as-errors` clean locally.
- [x] `mix test` — 155 tests, 0 failures.
- [ ] CI green on the new pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)