### PR TITLE
Move secret_key_base out of the base config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -11,9 +11,10 @@ config :webludo,
   ecto_repos: [WebLudo.Repo]
 
 # Configures the endpoint
+# secret_key_base is set per-environment: dev/test in their respective
+# config files, prod in config/runtime.exs from SECRET_KEY_BASE.
 config :webludo, WebLudoWeb.Endpoint,
   url: [host: "localhost"],
-  secret_key_base: "FLOYVRiQYbMc68sZSHmfExMRzIyI7thxEYwddsHPw3xlvFSQHNPCngM5G3H3Iazp",
   render_errors: [view: WebLudoWeb.ErrorView, accepts: ~w(html json)],
   pubsub_server: WebLudo.PubSub,
   live_view: [signing_salt: "SC1OdLtr"]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -16,6 +16,8 @@ config :webludo, WebLudo.Repo,
 # watchers to your application. For example, we use it
 # with webpack to recompile .js and .css sources.
 config :webludo, WebLudoWeb.Endpoint,
+  secret_key_base:
+    "8Pq92jawpMQF3X4HGq9dOORYeDM-vSZiXKK25vXwNrmbp5A-BcBLi0FHyEC67X6_zC5xiP5WQn-9udWRx9Sviw",
   http: [port: 4000],
   https: [
     port: 4001,

--- a/config/test.exs
+++ b/config/test.exs
@@ -11,6 +11,8 @@ config :webludo, WebLudo.Repo,
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :webludo, WebLudoWeb.Endpoint,
+  secret_key_base:
+    "RoSG5r2EoWGrOOQkKs3_iYA8ob2hL4j5RxNRKbFEpXzpF79Vb17HWUQMeWomYpEpXOKLgHCRmbqPv6QfOeb8yA",
   http: [port: 4002],
   server: false
 


### PR DESCRIPTION
## Summary
`config/config.exs` is loaded for every Mix env, so a `secret_key_base` hardcoded there ends up bundled into the prod release artifact even though `config/runtime.exs` overrides it at boot. Two issues:

- The dev key is in version control (already true).
- The prod release silently has the dev key as a fallback. If `SECRET_KEY_BASE` ever fails to be set on the VM, the release would serve traffic with the bundled dev key instead of failing loud.

This PR splits per-env:

- `config/dev.exs` and `config/test.exs` each get their own freshly generated `secret_key_base` (rotated from the prior shared value).
- `config/config.exs` no longer sets one; a comment points at the per-env locations and `runtime.exs` for prod.
- prod runtime is unchanged — `runtime.exs` continues to read `SECRET_KEY_BASE` from the environment. After this change, a missing env var in prod fails loud (no signing key) rather than silently using the bundled dev key.

## Test plan
- [x] `mix format --check-formatted` clean.
- [x] `mix compile --warnings-as-errors` clean.
- [x] `mix test` — 155 tests, 0 failures.
- [x] `MIX_ENV=prod mix release --overwrite` builds; the resulting release boots with `SECRET_KEY_BASE` supplied and shuts down cleanly.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)