### PR TITLE
Whitelist EctoAtom values to bound the atom table

### DIFF
--- a/lib/ecto_atom/atom.ex
+++ b/lib/ecto_atom/atom.ex
@@ -1,12 +1,45 @@
 defmodule EctoAtom do
+  @moduledoc """
+  Stores an atom in a string column. Round-trips only the atoms in
+  `WebLudo.Logic.Constants.valid_atoms/0`; anything else fails the
+  Ecto cast/load/dump callbacks with `:error`.
+
+  This guards against an atom-table-leak DoS that would arise from
+  calling `String.to_atom/1` on arbitrary input loaded from the DB.
+  """
+
   use Ecto.Type
+
+  alias WebLudo.Logic.Constants
 
   def type, do: :string
 
-  def cast(value), do: {:ok, value}
+  def cast(nil), do: {:ok, nil}
 
-  def load(value), do: {:ok, String.to_atom(value)}
+  def cast(value) when is_atom(value) do
+    if value in Constants.valid_atoms(), do: {:ok, value}, else: :error
+  end
 
-  def dump(value) when is_atom(value), do: {:ok, Atom.to_string(value)}
+  def cast(value) when is_binary(value), do: from_string(value)
+
+  def cast(_), do: :error
+
+  def load(nil), do: {:ok, nil}
+  def load(value) when is_binary(value), do: from_string(value)
+  def load(_), do: :error
+
+  def dump(nil), do: {:ok, nil}
+
+  def dump(value) when is_atom(value) do
+    if value in Constants.valid_atoms(), do: {:ok, Atom.to_string(value)}, else: :error
+  end
+
   def dump(_), do: :error
+
+  defp from_string(s) do
+    atom = String.to_existing_atom(s)
+    if atom in Constants.valid_atoms(), do: {:ok, atom}, else: :error
+  rescue
+    ArgumentError -> :error
+  end
 end

--- a/lib/webludo/logic/constants.ex
+++ b/lib/webludo/logic/constants.ex
@@ -6,6 +6,11 @@ defmodule WebLudo.Logic.Constants do
   # i.e. directly across the board from one another.
   @opposite_color_pairs [{:red, :yellow}, {:blue, :green}]
 
+  # Every atom that may legally appear in an EctoAtom-typed column. The
+  # whitelist guards against atom-table-leak DoS via String.to_atom on
+  # arbitrary input. Update this when a new color or area is added.
+  @valid_atoms @team_colors ++ [:none, :home, :play, :goal, :center]
+
   @team_order %{
     red: :blue,
     blue: :yellow,
@@ -46,6 +51,10 @@ defmodule WebLudo.Logic.Constants do
 
   def opposite_color_pairs do
     @opposite_color_pairs
+  end
+
+  def valid_atoms do
+    @valid_atoms
   end
 
   def next_team(color) do

--- a/test/ecto_atom/atom_test.exs
+++ b/test/ecto_atom/atom_test.exs
@@ -1,0 +1,75 @@
+defmodule EctoAtomTest do
+  use ExUnit.Case, async: true
+
+  describe "cast/1" do
+    test "accepts a whitelisted atom" do
+      assert {:ok, :red} = EctoAtom.cast(:red)
+      assert {:ok, :home} = EctoAtom.cast(:home)
+      assert {:ok, :none} = EctoAtom.cast(:none)
+    end
+
+    test "converts a whitelisted string to its atom" do
+      assert {:ok, :blue} = EctoAtom.cast("blue")
+      assert {:ok, :goal} = EctoAtom.cast("goal")
+    end
+
+    test "rejects an atom outside the whitelist" do
+      assert :error = EctoAtom.cast(:purple)
+      assert :error = EctoAtom.cast(:not_a_color)
+    end
+
+    test "rejects an unknown string without creating a new atom" do
+      assert :error = EctoAtom.cast("never_seen_this_string_before_2026")
+    end
+
+    test "rejects non-atom non-string input" do
+      assert :error = EctoAtom.cast(42)
+      assert :error = EctoAtom.cast(%{})
+      assert :error = EctoAtom.cast([])
+    end
+
+    test "passes nil through" do
+      assert {:ok, nil} = EctoAtom.cast(nil)
+    end
+  end
+
+  describe "load/1" do
+    test "loads a whitelisted string into its atom" do
+      assert {:ok, :red} = EctoAtom.load("red")
+      assert {:ok, :center} = EctoAtom.load("center")
+    end
+
+    test "rejects an unknown string without creating a new atom" do
+      assert :error = EctoAtom.load("not_a_real_atom_value_xyz")
+    end
+
+    test "rejects non-binary input" do
+      assert :error = EctoAtom.load(42)
+      assert :error = EctoAtom.load(:red)
+    end
+
+    test "passes nil through" do
+      assert {:ok, nil} = EctoAtom.load(nil)
+    end
+  end
+
+  describe "dump/1" do
+    test "dumps a whitelisted atom to its string" do
+      assert {:ok, "yellow"} = EctoAtom.dump(:yellow)
+      assert {:ok, "play"} = EctoAtom.dump(:play)
+    end
+
+    test "rejects an atom outside the whitelist" do
+      assert :error = EctoAtom.dump(:not_in_whitelist)
+    end
+
+    test "rejects non-atom input" do
+      assert :error = EctoAtom.dump("red")
+      assert :error = EctoAtom.dump(42)
+    end
+
+    test "passes nil through" do
+      assert {:ok, nil} = EctoAtom.dump(nil)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
The previous `EctoAtom` implementation called `String.to_atom/1` on whatever value `load/1` received from the DB and accepted any input in `cast/1` unconditionally. Either path could leak unbounded atoms (DoS — atoms aren't garbage-collected on the BEAM) or silently accept wrong-typed values that then crashed at `dump/1` time.

Three changes:

- `WebLudo.Logic.Constants.valid_atoms/0` returns the union of every atom that may legally appear in an `EctoAtom`-typed column: `team_colors() ++ [:none, :home, :play, :goal, :center]`. Single source of truth; the surveyed atom universe in the codebase exactly matches this list.
- `EctoAtom.cast/1`, `load/1`, and `dump/1` each accept only whitelisted values and return `:error` for anything else. The string→atom conversion uses `String.to_existing_atom/1` wrapped with `rescue` so an unknown string can never create a new atom regardless of how it reached the type. `nil` is passed through (preserves compatibility with nullable columns).
- New unit tests in `test/ecto_atom/atom_test.exs` cover: atoms in whitelist, atoms out of whitelist, strings in whitelist, unknown strings, non-atom non-string input, and `nil` — for each of `cast`, `load`, and `dump`.

## Test plan
- [x] `mix format --check-formatted` clean.
- [x] `mix compile --warnings-as-errors` clean.
- [x] `mix test` — 169 tests, 0 failures (155 existing + 14 new EctoAtom unit tests).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)