### PR TITLE
Allow webludo.oni.dev and daemon-king.exe.xyz to open the websocket

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -3,7 +3,13 @@ import Config
 # Origins allowed to open the websocket. The host (PHX_HOST) is set in
 # config/runtime.exs from the environment.
 config :webludo, WebLudoWeb.Endpoint,
-  check_origin: ["//localhost:*", "//webludo.netlify.com", "//webludo.katris.dev"]
+  check_origin: [
+    "//localhost:*",
+    "//webludo.netlify.com",
+    "//webludo.katris.dev",
+    "//webludo.oni.dev",
+    "//daemon-king.exe.xyz"
+  ]
 
 # Do not print debug messages in production
 config :logger, level: :info


### PR DESCRIPTION
## Summary
A secondary frontend deployment is being set up on a VM next to the API as a fallback path around a config issue with the primary frontend at `webludo.katris.dev`. Two new origins need `check_origin` clearance for that VM:

- `webludo.oni.dev` — the secondary frontend's custom domain.
- `daemon-king.exe.xyz` — the auto-generated exe.dev hostname for the same VM, useful while DNS for the custom domain settles or for direct testing.

The existing `webludo.katris.dev` origin stays in the list; nothing is being removed.

## Test plan
- [x] `mix format --check-formatted` clean.
- [x] `mix compile --warnings-as-errors` clean.
- [x] `mix test` — 173 tests, 0 failures.
- [x] CI green.
- [ ] After redeploy, the secondary frontend at `webludo.oni.dev` (and via the `daemon-king.exe.xyz` fallback) can open the websocket against `webludo-api.oni.dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)