### PR TITLE
Document webludo.oni.dev as the active frontend URL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Phoenix API server for a multiplayer Beer-Ludo (Finnish "Kimble") game. Live at `https://webludo-api.oni.dev`. Frontend at `https://webludo.katris.dev` lives in a separate repo (`katrimarika/kimble-frontend`) and is out of scope here.
+Phoenix API server for a multiplayer Beer-Ludo (Finnish "Kimble") game. Live at `https://webludo-api.oni.dev`. Frontend lives in a separate repo (`katrimarika/kimble-frontend`) — out of scope here. Primary deployment is `https://webludo.katris.dev`; while a config issue there is being resolved, `https://webludo.oni.dev` is the current active URL.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Webludo
 
-This project is a Phoenix server that handles running a game of beer-Ludo ("Kalja-Kimble"). The API is based on Phoenix channels. A Postgres-based persistence layer is included for longer games. See [the Preact frontend project](https://github.com/katrimarika/kimble-frontend) for the corresponding web client. The current version of the game can be played at https://webludo.katris.dev/.
+This project is a Phoenix server that handles running a game of beer-Ludo ("Kalja-Kimble"). The API is based on Phoenix channels. A Postgres-based persistence layer is included for longer games. See [the Preact frontend project](https://github.com/katrimarika/kimble-frontend) for the corresponding web client. The primary deployment of the frontend is at https://webludo.katris.dev/; while a config issue there is being resolved, https://webludo.oni.dev/ is the current playable URL.
 
 ## Initial local setup
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -166,8 +166,10 @@ curl -sS -o /dev/null -w "%{http_code}\n" https://webludo-api.oni.dev/socket/web
 ```
 
 A `400` or `426` is expected — the websocket endpoint rejects plain HTTP
-upgrade attempts but proves the path is wired end to end. The frontend at
-`https://webludo.katris.dev` should now connect.
+upgrade attempts but proves the path is wired end to end. The frontend
+should now connect: the primary deployment at `https://webludo.katris.dev`
+or, while a config issue there is being resolved, the fallback at
+`https://webludo.oni.dev`.
 
 ## Subsequent deploys
 


### PR DESCRIPTION
## Summary
The primary frontend at `webludo.katris.dev` has a config issue being worked on; the secondary deployment at `webludo.oni.dev` is the currently-playable path. Three files mentioned only katris.dev:

- `README.md` — points readers at the live game.
- `CLAUDE.md` — orientation file loaded into every Claude Code session.
- `deploy/README.md` — Verify step in the bootstrap runbook.

Each now names the primary (katris.dev) and the active fallback (oni.dev) with one line on why the fallback exists. Once the config issue is resolved at katris.dev, the fallback wording can come back out in a follow-up.

## Test plan
- [x] `mix format --check-formatted` clean.
- [x] `mix compile --warnings-as-errors` clean.
- [x] `mix test` — 173 tests, 0 failures.
- [x] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)